### PR TITLE
修复<button>标签嵌套的错误

### DIFF
--- a/backend/app/im/page.tsx
+++ b/backend/app/im/page.tsx
@@ -1482,11 +1482,19 @@ function IMPageInner() {
     const prefixWidth = depth > 0 ? depth * guideWidth + guideWidth : 0;
     const previewIndent = tree ? prefixWidth + caretWidth + caretGap : 0;
     return (
-      <button
+      <div
         key={g.id}
         className={cx("row", g.id === activeGroupId && "active")}
+        role="button"
+        tabIndex={0}
         onClick={() => {
           setActiveGroupId(g.id);
+        }}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            setActiveGroupId(g.id);
+          }
         }}
         style={{ paddingLeft: 16 }}
       >
@@ -1562,7 +1570,7 @@ function IMPageInner() {
             </div>
           </div>
         )}
-      </button>
+      </div>
     );
   };
 


### PR DESCRIPTION
我使用了DeepSeek的deepseek-reasoner模型做测试，修改了相应的BASE_URL、API_KEY，使用中发现让Agent操作子Agent的时候，Next会报一些&lt;button&gt;标签嵌套的错误。

本PR对该问题进行了简单修复。

详细报错内容如下：

### Error 1/2:

```
## Error Type
Console Error

## Error Message
In HTML, <button> cannot be a descendant of <button>.
This will cause a hydration error.

  ...
    <RedirectErrorBoundary router={{...}}>
      <InnerLayoutRouter url="/im?worksp..." tree={[...]} params={{}} cacheNode={{rsc:<Fragment>, ...}} ...>
        <SegmentViewNode type="page" pagePath="im/page.tsx">
          <SegmentTrieNode>
          <ClientPageRoot Component={function IMPage} serverProvidedParams={{...}}>
            <IMPage params={Promise} searchParams={Promise}>
              <Suspense fallback={<div>}>
                <IMPageInner>
                  <IMShell left={<aside>} mid={<main>} right={<Fragment>}>
                    <div className="app dark">
                      <aside className="panel pane...">
                        <div>
                        <div>
                        <div className="list">
>                         <button className="row active" onClick={function onClick} style={{paddingLeft:16}}>
                            <div style={{display:"flex", ...}}>
                              <div style={{display:"flex", ...}}>
>                               <button type="button" className="tree-caret" onClick={function onClick} title="收起">
                                ...
                            ...
                          ...
                          ...
                      ...
        ...
      ...



    at button (<anonymous>:null:null)
    at renderGroupRow (.next\dev\static\chunks\app_im_34711470._.js:1955:255)
    at <unknown> (.next\dev\static\chunks\app_im_34711470._.js:2227:122)
    at Array.map (<anonymous>:null:null)
    at IMPageInner (.next\dev\static\chunks\app_im_34711470._.js:2227:43)
    at IMPage (.next\dev\static\chunks\app_im_34711470._.js:307:221)

Next.js version: 16.1.6 (Turbopack)
```

### Error 2/2:

```
## Error Type
Console Error

## Error Message
<button> cannot contain a nested <button>.
See this log for the ancestor stack trace.


    at button (<anonymous>:null:null)
    at renderGroupRow (.next\dev\static\chunks\app_im_34711470._.js:1908:218)
    at <unknown> (.next\dev\static\chunks\app_im_34711470._.js:2227:122)
    at Array.map (<anonymous>:null:null)
    at IMPageInner (.next\dev\static\chunks\app_im_34711470._.js:2227:43)
    at IMPage (.next\dev\static\chunks\app_im_34711470._.js:307:221)

Next.js version: 16.1.6 (Turbopack)
```